### PR TITLE
Returns result if no product is found

### DIFF
--- a/Plugin/ProductEavDataProviderPlugin.php
+++ b/Plugin/ProductEavDataProviderPlugin.php
@@ -58,6 +58,10 @@ class ProductEavDataProviderPlugin
         $storeViews = $this->getStores();
         $product = $this->registry->registry('current_product');
 
+        if ($product->getId() === null) {
+            return $result;
+        }
+
         foreach ($storeViews as $storeView) {
             $productByStoreCode = $this->getProductInStoreView($product->getId(), $storeView->getId());
             $currentScopeValueForCode = $value = $productByStoreCode->getData($attributeCode);


### PR DESCRIPTION
Dear Herr Studnitz,

While developing a web store using your handy plugin I discovered a game-breaking bug.

**Bug**
The bug in question would throw an exception when I wanted to add a new product to the catalog.
Upon closer inspection I discovered that your plugin always assumes that a product is found before it runs a certain foreach() loop. But if I were to make a new product then no product is found and an exception is thrown.

**Solution**
As a solution I've implemented a tiny if() statement that checks whether or not the $product variable has an id. If it doesn't then the $result is returned. This means that the foreach() loop needing product information is not run and the exception is not thrown. Of course, when an id has been found then it resumes operation like you intended.

This small solution works on my store as expected. I hope that you will find my solution useful. If you have any questions, feedback or other remarks please feel free to contact me.

Kind regards,
Daniël Riezebos