### PR TITLE
Fix array to string conversion exception

### DIFF
--- a/Plugin/ConfigFieldPlugin.php
+++ b/Plugin/ConfigFieldPlugin.php
@@ -129,16 +129,23 @@ class ConfigFieldPlugin
         $path = $this->getPath($field);
         $scopeLine = '';
         if ($websiteId = $this->getWebsiteParam()) {
-            $currentValue = (string) $this->scopeConfig->getValue(
+            $currentValue = $this->scopeConfig->getValue(
                 $path,
                 ScopeInterface::SCOPE_WEBSITE,
                 $websiteId
             );
         } else {
-            $currentValue = (string) $this->scopeConfig->getValue($path);
+            $currentValue = $this->scopeConfig->getValue($path);
         }
-        $scopeValue = (string) $this->scopeConfig->getValue($path, $scopeType, $scope->getId());
-        
+        $scopeValue = $this->scopeConfig->getValue($path, $scopeType, $scope->getId());
+
+        if (is_array($currentValue) || is_array($scopeValue)) {
+            return $scopeLine;
+        }
+
+        $currentValue = (string) $currentValue;
+        $scopeValue = (string) $scopeValue;
+
         if ($scopeValue != $currentValue) {
             $scopeValue = $this->escaper->escapeHtml($scopeValue);
 


### PR DESCRIPTION
Changes in https://github.com/avstudnitz/AvS_ScopeHint2/pull/28 introduced a change where the current value and scope value are cast to string. This leads however to the following exception, when using an array-serialized/serialized config field in store configuration: 

`Exception #0 (Exception): Warning: Array to string conversion in /var/www/html/vendor/avstudnitz/scopehint2/Plugin/ConfigFieldPlugin.php on line 138`

Since the array values can be structured in multiple ways, I propose to just skip the array values and not generate a scope hint label for such cases. These kind of arrays often contain multiple entries anyways, so displaying changes in a popover is tricky anyways.

Noticed the bug while trying to configure the [DHL extension](https://github.com/netresearch/dhl-shipping-m2) which uses a custom [ArraySerialized](https://github.com/netresearch/module-shipping-core/blob/master/Model/Config/Backend/ArraySerialized.php) class. But Magento has those kind of classes in the core as well.