### PR TITLE
Fix ScopeHints for config fields returning `array` values

### DIFF
--- a/Plugin/ConfigFieldPlugin.php
+++ b/Plugin/ConfigFieldPlugin.php
@@ -137,7 +137,14 @@ class ConfigFieldPlugin
         } else {
             $currentValue = (string) $this->scopeConfig->getValue($path);
         }
-        $scopeValue = (string) $this->scopeConfig->getValue($path, $scopeType, $scope->getId());
+
+        $scopeValue = $this->scopeConfig->getValue($path, $scopeType, $scope->getId());
+
+        if (is_array($scopeValue)) {
+            return '';
+        }
+
+        $scopeValue = (string) $scopeValue;        
         
         if ($scopeValue != $currentValue) {
             $scopeValue = $this->escaper->escapeHtml($scopeValue);


### PR DESCRIPTION
Error message was:

```
Exception: Notice: Array to string conversion in [...]/vendor/avstudnitz/scopehint2/Plugin/ConfigFieldPlugin.php on line 140 
```