### PR TITLE
Avoid calculating the path_hint more then once per field. Fixes infin…

### DIFF
--- a/Plugin/ConfigFieldPlugin.php
+++ b/Plugin/ConfigFieldPlugin.php
@@ -39,6 +39,11 @@ class ConfigFieldPlugin
      */
     private $request;
 
+    /**
+     * @var array<string>
+     */
+    private $handledFields = [];
+
     public function __construct(
         Escaper $escaper,
         ScopeConfigInterface $scopeConfig,
@@ -98,7 +103,15 @@ class ConfigFieldPlugin
             return $result;
         }
 
-        $result['path_hint'] = '<small>' . __('Path: <code>%1</code>', $this->getPath($subject) . '</small>');
+        // make sure we only calculate the path hint once
+        // there is a known issue with a plugin from the MultiSafepay module (FieldPlugin) that can cause an infinite loop
+        // this solves it by calculating the field's object hash and making sure we only call getPath once per Field
+        $fieldObjectHash = spl_object_hash($subject);
+        if (!in_array($fieldObjectHash, $this->handledFields, true)) {
+            $this->handledFields[] = $fieldObjectHash;
+
+            $result['path_hint'] = '<small>' . __('Path: <code>%1</code>', $this->getPath($subject) . '</small>');
+        }
 
         return $result;
     }


### PR DESCRIPTION
…ite loop when MultiSafepay module is installed.

## Description
We ran into a bug when both AvS_ScopeHint2 and the [MultiSafepay payment module](https://github.com/MultiSafepay/magento2) were installed at the same time.
This started happening after the change from https://github.com/avstudnitz/AvS_ScopeHint2/pull/35 (introduced in version 1.2.3)

The MultiSafepay module also has [a plugin](https://github.com/MultiSafepay/magento2-adminhtml/blob/a4d0d8ab0791d153de7439a2026ddfe462068ce8/Plugin/Model/Config/Element/FieldPlugin.php
) on `Magento\Config\Model\Config\Structure\Element\Field`.

And when going in the backoffice to "Stores > Configuration > MultiSafepay > Payment Gateways", an infinite loop got triggered, stack trace simplified:

1. Magento\Config\Model\Config\Structure\Element\Field::getConfigPath
2. MultiSafepay\ConnectAdminhtml\Plugin\Model\Config\Element\FieldPlugin::afterGetConfigPath
3. MultiSafepay\ConnectAdminhtml\Plugin\Model\Config\Element\FieldPlugin::getGenericGatewayConfigPath
4. Magento\Config\Model\Config\Structure\Element\Field::getData
5. AvS\ScopeHint\Plugin\ConfigFieldPlugin::afterGetData
6. AvS\ScopeHint\Plugin\ConfigFieldPlugin::getPath
7. Magento\Config\Model\Config\Structure\Element\Field::getConfigPath
8. and from here on out we're back to step 2 and on and on and on...

## Solution
I tried a couple of options, but in order to uniquely identify a Field, I always needed to call some `getXXX` method on it which then triggered another infinite loop
So I settled for using the [`spl_object_hash` function](https://www.php.net/manual/en/function.spl-object-hash.php) which gives each PHP Object (a Field in this case) a unique hash so we can identify if the plugin already got executed for a specific field or not.
This avoid the infinite loop.

Feel free to let me know if you see another solution.
