### PR TITLE
Avoid calculating the path_hint fails

### DIFF
--- a/Plugin/ConfigFieldPlugin.php
+++ b/Plugin/ConfigFieldPlugin.php
@@ -39,10 +39,10 @@ class ConfigFieldPlugin
      */
     private $request;
 
-    /**
-     * @var array<string>
-     */
-    private $handledFields = [];
+     /**
+     * @var bool
+      */
+    private $isProcessing = false;
 
     public function __construct(
         Escaper $escaper,
@@ -103,16 +103,14 @@ class ConfigFieldPlugin
             return $result;
         }
 
-        // make sure we only calculate the path hint once
-        // there is a known issue with a plugin from the MultiSafepay module (FieldPlugin) that can cause an infinite loop
-        // this solves it by calculating the field's object hash and making sure we only call getPath once per Field
-        // NB For the configuration, this fails as the subject is always "Magento\Config\Model\Config\Structure\Element\Field\Interceptor"
-        $fieldObjectHash = spl_object_hash($subject);
-        if (!in_array($fieldObjectHash, $this->handledFields, true) || empty($result['path_hint'])) {
-            $this->handledFields[] = $fieldObjectHash;
+        // to avoid a potential infinite loop, we keep a flag to see if we are already handling this particular field
+        if (!$this->isProcessing) {
+            $this->isProcessing = true;
 
-            $result['path_hint'] = '<small>' . __('Path: <code>%1</code>', $this->getPath($subject) . '</small>');
-        }
+             $result['path_hint'] = '<small>' . __('Path: <code>%1</code>', $this->getPath($subject) . '</small>');
+
+            $this->isProcessing = false;
+         }
 
         return $result;
     }

--- a/Plugin/ConfigFieldPlugin.php
+++ b/Plugin/ConfigFieldPlugin.php
@@ -106,8 +106,9 @@ class ConfigFieldPlugin
         // make sure we only calculate the path hint once
         // there is a known issue with a plugin from the MultiSafepay module (FieldPlugin) that can cause an infinite loop
         // this solves it by calculating the field's object hash and making sure we only call getPath once per Field
+        // NB For the configuration, this fails as the subject is always "Magento\Config\Model\Config\Structure\Element\Field\Interceptor"
         $fieldObjectHash = spl_object_hash($subject);
-        if (!in_array($fieldObjectHash, $this->handledFields, true)) {
+        if (!in_array($fieldObjectHash, $this->handledFields, true) || empty($result['path_hint'])) {
             $this->handledFields[] = $fieldObjectHash;
 
             $result['path_hint'] = '<small>' . __('Path: <code>%1</code>', $this->getPath($subject) . '</small>');


### PR DESCRIPTION
With 1.3.1 , the change to avoid calculating the path_hint doesn't work. Each object is the same in the configuration, resulting in no path hints being shown.