### PR TITLE
Deduplication of plugin type name

### DIFF
--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -4,10 +4,6 @@
         <plugin name="avs_scopehint_plugin_add_tooltip_to_product_field" type="AvS\ScopeHint\Plugin\ConfigFieldPlugin" sortOrder="1" disabled="false" />
     </type>
 
-    <type name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav">
-        <plugin name="avs_scopehint_plugin_field" type="AvS\ScopeHint\Plugin\ProductEavDataProviderPlugin" sortOrder="1" disabled="false" />
-    </type>
-
     <type name="Magento\Config\Block\System\Config\Form\Field">
         <plugin name="avs_scopehint_plugin_add_config_path"
                 type="AvS\ScopeHint\Plugin\ConfigFormFieldPlugin"
@@ -16,9 +12,13 @@
     </type>
 
     <type name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav">
+        <plugin name="avs_scopehint_plugin_field"
+                type="AvS\ScopeHint\Plugin\ProductEavDataProviderPlugin"
+                sortOrder="1"
+                disabled="false" />
         <plugin name="avs_scopehint_plugin_add_attribute_code"
                 type="AvS\ScopeHint\Plugin\UIScopeLabel"
                 sortOrder="1"
-                disabled="false"/>
+                disabled="false" />
     </type>
 </config>


### PR DESCRIPTION
With 1.3.2 there will be more than one matching query to Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav.

Issue comes after running setup:upgrade:

```
More than one node matching the query: /config/type[@name='Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav'], Xml is: <?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
    <type name="Magento\Config\Model\Config\Structure\Element\Field">
        <plugin name="avs_scopehint_plugin_add_tooltip_to_product_field" type="AvS\ScopeHint\Plugin\ConfigFieldPlugin" sortOrder="1" disabled="false"/>
    </type>

    <type name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav">
        <plugin name="avs_scopehint_plugin_field" type="AvS\ScopeHint\Plugin\ProductEavDataProviderPlugin" sortOrder="1" disabled="false"/>
    </type>

    <type name="Magento\Config\Block\System\Config\Form\Field">
        <plugin name="avs_scopehint_plugin_add_config_path" type="AvS\ScopeHint\Plugin\ConfigFormFieldPlugin" sortOrder="1" disabled="false"/>
    </type>

    <type name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav">
        <plugin name="avs_scopehint_plugin_add_attribute_code" type="AvS\ScopeHint\Plugin\UIScopeLabel" sortOrder="1" disabled="false"/>
    </type>
...
```