### PR TITLE
Partial refactoring

### DIFF
--- a/Plugin/ConfigFieldPlugin.php
+++ b/Plugin/ConfigFieldPlugin.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace AvS\ScopeHint\Plugin;
 
 use Magento\Config\Model\Config\Structure\Element\Field as Subject;
@@ -25,24 +28,24 @@ class ConfigFieldPlugin
     /**
      * @var ScopeConfigInterface
      */
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
     /**
      * @var WebsiteRepositoryInterface
      */
-    private $websiteRepository;
+    private WebsiteRepositoryInterface $websiteRepository;
     /**
      * @var StoreRepositoryInterface
      */
-    private $storeRepository;
+    private StoreRepositoryInterface $storeRepository;
     /**
      * @var RequestInterface
      */
-    private $request;
+    private RequestInterface $request;
 
      /**
      * @var bool
       */
-    private $isProcessing = false;
+    private bool $isProcessing = false;
 
     public function __construct(
         Escaper $escaper,
@@ -173,7 +176,7 @@ class ConfigFieldPlugin
         return $scopeLine;
     }
 
-    private function getValueLabel(Subject $field, string $scopeValue): string
+    private function getValueLabel(Subject $field, string $scopeValue)
     {
         $scopeValue = trim($scopeValue);
         if ($field->hasOptions()) {

--- a/Plugin/ProductEavDataProviderPlugin.php
+++ b/Plugin/ProductEavDataProviderPlugin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AvS\ScopeHint\Plugin;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
@@ -11,16 +13,16 @@ use Magento\Catalog\Model\Attribute\ScopeOverriddenValue;
 class ProductEavDataProviderPlugin
 {
     /** @var StoreManagerInterface */
-    private $storeManager;
+    private StoreManagerInterface $storeManager;
 
     /** @var Registry */
-    private $registry;
+    private Registry $registry;
 
     /** @var ProductRepositoryInterface */
-    private $productRepository;
+    private ProductRepositoryInterface $productRepository;
 
     /** @var array */
-    private $stores;
+    private ?array $stores = null;
 
     /**
      * ProductEavDataProviderPlugin constructor.
@@ -116,7 +118,7 @@ class ProductEavDataProviderPlugin
     /**
      * @return array
      */
-    private function getStores()
+    private function getStores(): array
     {
         if (!$this->stores) {
             $this->stores = $this->storeManager->getStores();

--- a/Plugin/UIScopeLabel.php
+++ b/Plugin/UIScopeLabel.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace AvS\ScopeHint\Plugin;
 
 use Magento\Catalog\Api\Data\ProductAttributeInterface;
@@ -14,16 +17,16 @@ class UIScopeLabel
     /**
      * @var ArrayManager
      */
-    private $arrayManager;
+    private ArrayManager $arrayManager;
 
     /**
      * @var ScopeConfigInterface
      */
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
 
     public function __construct(
         ArrayManager $arrayManager,
-        ScopeConfigInterface $scopeConfig,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->arrayManager = $arrayManager;
         $this->scopeConfig = $scopeConfig;
@@ -41,20 +44,22 @@ class UIScopeLabel
             return $result;
         }
 
+        if ($attribute->getFrontendInput() === AttributeInterface::FRONTEND_INPUT) {
+            return $result;
+        }
+
         $configPath = ltrim(EavModifier::META_CONFIG_PATH, ArrayManager::DEFAULT_PATH_DELIMITER);
         $scopeLabel = $this->arrayManager->get(
             $configPath . ArrayManager::DEFAULT_PATH_DELIMITER . 'scopeLabel',
             $result
         );
 
-        if ($attribute->getFrontendInput() !== AttributeInterface::FRONTEND_INPUT) {
-            $scopeLabel = $attribute->getAttributeCode() . ' ' . (string)$scopeLabel;
-            $result = $this->arrayManager->merge(
-                $configPath,
-                $result,
-                ['scopeLabel' => trim($scopeLabel)]
-            );
-        }
+        $scopeLabel = $attribute->getAttributeCode() . ' ' . (string)$scopeLabel;
+        $result = $this->arrayManager->merge(
+            $configPath,
+            $result,
+            ['scopeLabel' => trim($scopeLabel)]
+        );
 
         return $result;
     }


### PR DESCRIPTION
- Mandatory strict types for all PHP files
- Make code compatible with PHP 7.4 (still some Magento stores there)
- Not calculate data when we do not know yet, that will be used (in `Plugin/UIScopeLabel.php`)
- `getValueLabel` sometimes returning `Phrase` instead of `string` 