### PR TITLE
Fix DI compilation syntax error "unexpected ')', expecting variable (T_VARIABLE)" on php 7.4

### DIFF
--- a/Plugin/UIScopeLabel.php
+++ b/Plugin/UIScopeLabel.php
@@ -23,7 +23,7 @@ class UIScopeLabel
 
     public function __construct(
         ArrayManager $arrayManager,
-        ScopeConfigInterface $scopeConfig,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->arrayManager = $arrayManager;
         $this->scopeConfig = $scopeConfig;


### PR DESCRIPTION
On Magento 2.4.2 and PHP 7.4 got such an error during DI compilation:

```
❯ magento setup:di:compile
Compilation was started.
Repositories code generation... 1/9 [===>------------------------]  11% < 1 sec 108.0 MiBPHP Parse error:  syntax error, unexpected ')', expecting variable (T_VARIABLE) in /var/www/html/vendor/avstudnitz/scopehint2/Plugin/UIScopeLabel.php on line 27

Parse error: syntax error, unexpected ')', expecting variable (T_VARIABLE) in /var/www/html/vendor/avstudnitz/scopehint2/Plugin/UIScopeLabel.php on line 27
```